### PR TITLE
[PMD-945] Add manifest build.id override to get rid of '-1' issue.

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -269,5 +269,41 @@
 		</if>
 	</target>	
 
+   <!--=======================================================================
+      generate.manifest
+      
+      Creates a new manifest file if one is not specified, or updates
+      an existing manifest file if one is specified. 
+      Overriding this target in subfloor.xml to address BISERVER-10516
+      ====================================================================-->
+        <target name="generate.manifest" depends="init,set-build.id">
+            <delete file="${dist.manifest.file}" />
+            <touch file="${dist.manifest.file}" />
+            <copy file="${manifest.file}" tofile="${dist.manifest.file}" overwrite="true" failonerror="false" />
+
+            <manifest file="${dist.manifest.file}" mode="update">
+                      <attribute name="Implementation-Title" value="${impl.title}" />
+                      <attribute name="Implementation-Version" value="${project.revision}${build.id}" />
+                      <attribute name="Implementation-Vendor" value="${impl.vendor}" />
+                      <attribute name="Implementation-ProductID" value="${impl.productID}" />
+            </manifest>
+          </target>
+
+    <!--=======================================================================
+      set-build.id
+      
+      Overriding this target in subfloor.xml to address BISERVER-10516
+      ====================================================================-->
+        <target name="set-build.id" unless="build.id" depends="install-antcontrib">
+            <if>
+                  <istrue value="${release}" />
+            <then>
+                  <property name="build.id" value="" />
+            </then>
+            <else>
+                  <property name="build.id" value=".development" />
+            </else>
+            </if>
+          </target>
 
 </project>


### PR DESCRIPTION
"Version numbering incorrect with 5.0.3 in Help>about"
