### PR TITLE
[PMD-962] Encoding/Decoding - Not able to publish a Domain from PME with multiple special characters in the name

### DIFF
--- a/src/org/pentaho/pms/ui/dialog/PublishDialog.java
+++ b/src/org/pentaho/pms/ui/dialog/PublishDialog.java
@@ -255,7 +255,7 @@ public class PublishDialog extends TitleAreaDialog {
             .field("metadataFile", fileStream, MediaType.MULTIPART_FORM_DATA_TYPE);
         part.getField("metadataFile").setContentDisposition(
             FormDataContentDisposition.name("metadataFile")
-            .fileName(userDomain).build());
+            .fileName("metadataFile" + System.currentTimeMillis()).build());
         Client client = Client.create();
         client.addFilter(new HTTPBasicAuthFilter(userId, userPassword));
       


### PR DESCRIPTION
The filename is an unused field on the server except for writing tmp files.  If the tmp file contains illegal characters for the OS, then the REST call will fail before it is allowed to even get into our Resource.  The fix here is to create names which are safe (for any OS) as this does not interfere with the publishing of domains with names like D-[~!@#$%^&*(){}|.,]-=_+|;'"?<>~`: . 
