### PR TITLE
[PMD-976] - Updated the Metadata Editor's Info.plist to specify the corr...

### DIFF
--- a/package-res/Metadata Editor.app/Contents/Info.plist
+++ b/package-res/Metadata Editor.app/Contents/Info.plist
@@ -28,7 +28,7 @@
 	<dict>
 		<key>ClassPath</key>
 		<array>
-			<string>./launcher/launcher.jar</string>
+			<string>./launcher/pentaho-application-launcher.jar</string>
 			<string>./libswt/osx64/swt.jar</string>
 		</array>
 		<key>JVMVersion</key>


### PR DESCRIPTION
...ect name for the application launcher jar - this is what was preventing the OSX .app from being able to launch the application