### PR TITLE
[BACKLOG-5191] Missing additional quotes on batch file for PDI and Me…

### DIFF
--- a/package-res/metadata-editor.bat
+++ b/package-res/metadata-editor.bat
@@ -81,7 +81,7 @@ REM ** Change 2048m to higher values in case you run out of memory  **
 REM ** or set the PENTAHO_JAVA_OPTIONS environment variable         **
 REM ******************************************************************
 
-if "%PENTAHO_JAVA_OPTIONS%"=="" set PENTAHO_JAVA_OPTIONS="-Xms1024m -Xmx2048m"
+if "%PENTAHO_JAVA_OPTIONS%"=="" set PENTAHO_JAVA_OPTIONS="-Xms1024m" "-Xmx2048m"
 
 set OPT=%PENTAHO_JAVA_OPTIONS% "-Djava.library.path=%LIBSPATH%" 
 rem **** USE THIS LINE IF REMOTE DEBUGGING (port 5105) IS REQUIRED***


### PR DESCRIPTION
…tadata Editor when set PENTAHO JAVA_OPTIONS (Windows only)