### PR TITLE
[SP-2769] - Backport of PPP-3537 - Use of vulnerable component com.th…

### DIFF
--- a/build.properties
+++ b/build.properties
@@ -26,7 +26,7 @@ dependency.pentaho-cassandra-plugin.revision=6.1-SNAPSHOT
 dependency.pentaho-mongodb-plugin.revision=6.1-SNAPSHOT
 dependency.pdi-spark-plugin.revision=6.1-SNAPSHOT
 dependency.pentaho-palo-core.revision=6.1-SNAPSHOT
-dependency.xstream.revision=1.4.2
+dependency.xstream.revision=1.4.9
 dependency.oss-licenses.revision=6.1-SNAPSHOT
 
 dependency.launcher.revision=6.1-SNAPSHOT

--- a/ivy.xml
+++ b/ivy.xml
@@ -68,9 +68,10 @@
         <dependency org="com.h2database" name="h2" rev="1.0.20070617" transitive="false" conf="drivers->default" />
         <dependency org="pentaho" name="pentaho-hadoop-hive-jdbc-shim" rev="${dependency.pentaho-hadoop-hive-jdbc-shim.revision}" conf="drivers->default" />
 
-        <!--  also pull down xstream and its dependencies -->
-        <dependency org="com.thoughtworks.xstream" name="xstream"  rev="${dependency.xstream.revision}" transitive="false" conf="default->default"/>
-        <dependency org="xpp3"                     name="xpp3_min" rev="1.1.4c" transitive="false" conf="default->default"/>
+        <!-- xstream with dependencies -->
+        <dependency org="xmlpull" name="xmlpull" rev="1.1.3.1" transitive="false" conf="default->default"/>
+        <dependency org="xpp3" name="xpp3_min" rev="1.1.4c" transitive="false" conf="default->default"/>
+        <dependency org="com.thoughtworks.xstream" name="xstream" rev="${dependency.xstream.revision}" transitive="false" conf="default->default"/>
 
         <!-- pentaho-xul-framework must match JARs required by kettle-ui-swt -->
         <!-- this manual sync should go away once this project is propertly ivy-ized -->


### PR DESCRIPTION
…oughtworks.xstream v1.4.2 CVE-2013-7285 (6.1 Suite)

@pamval, @mbatchelor, here is backport of https://github.com/pentaho/pentaho-metadata-editor/pull/58 to 6.1. Thanks.  