### PR TITLE
[BACKLOG-10623] Upgrade the platform (non-OSGi side) to Spring Security 4 - spring.framework upgraded to 4.3.2.RELEASE - spring.security upgraded to 4.1.3.RELEASE

### DIFF
--- a/build.properties
+++ b/build.properties
@@ -17,7 +17,7 @@ dependency.pentaho-xul.revision=7.0-SNAPSHOT
 dependency.bi-platform.revision=7.0-SNAPSHOT
 dependency.pentaho-vfs-browser.revision=7.0-SNAPSHOT
 dependency.pdi-dataservice-plugin.revision=7.0-SNAPSHOT
-dependency.spring.security.revision=2.0.8.RELEASE
+dependency.spring.security.revision=4.1.3.RELEASE
 
 dependency.reporting-library.revision=7.0-SNAPSHOT
 


### PR DESCRIPTION
@pentaho/rogueone 
Part of Spring 4 upgrade.