### PR TITLE
[BACKLOG-11620] Update product App icons and splash screens

### DIFF
--- a/src/org/pentaho/pms/ui/util/Splash.java
+++ b/src/org/pentaho/pms/ui/util/Splash.java
@@ -76,7 +76,7 @@ public class Splash {
         e.gc.setBackground( new Color( e.display, new RGB( 255, 255, 255 ) ) );
         // Updates for PMD-190 - Use version helper to display version information
         VersionHelper helper = new VersionHelper();
-        e.gc.setForeground( Display.getDefault().getSystemColor( SWT.COLOR_BLACK ) );
+        e.gc.setForeground( Display.getDefault().getSystemColor( SWT.COLOR_WHITE ) );
         Font font = new Font( e.display, "Sans", 10, SWT.BOLD ); //$NON-NLS-1$
         e.gc.setFont( font );
         e.gc.setAntialias( SWT.ON );


### PR DESCRIPTION
	- switching splash screen text from black to white ( as the new 7.0 splash screen image has a dark blue background )