### PR TITLE
[BACKLOG-11620] Update product App icons and splash screens (#76)

### DIFF
--- a/src/org/pentaho/pms/ui/util/Splash.java
+++ b/src/org/pentaho/pms/ui/util/Splash.java
@@ -76,7 +76,7 @@ public class Splash {
         e.gc.setBackground( new Color( e.display, new RGB( 255, 255, 255 ) ) );
         // Updates for PMD-190 - Use version helper to display version information
         VersionHelper helper = new VersionHelper();
-        e.gc.setForeground( Display.getDefault().getSystemColor( SWT.COLOR_BLACK ) );
+        e.gc.setForeground( Display.getDefault().getSystemColor( SWT.COLOR_WHITE ) );
         Font font = new Font( e.display, "Sans", 10, SWT.BOLD ); //$NON-NLS-1$
         e.gc.setFont( font );
         e.gc.setAntialias( SWT.ON );


### PR DESCRIPTION
[CHERRY-PICK] https://github.com/pentaho/pentaho-metadata-editor/commit/8e5a5024a13691c02a32c02d39e5172d2b71e483

- switching splash screen text from black to white ( as new 7.0 splash screen image has a dark blue background )