### PR TITLE
[PSW-229] Script files don't have an header with Copyright data

### DIFF
--- a/package-res/metadata-editor.bat
+++ b/package-res/metadata-editor.bat
@@ -11,7 +11,7 @@
 @REM without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
 @REM See the GNU Lesser General Public License for more details.
 @REM
-@REM Copyright (c) 2009-2017 Pentaho Corporation..  All rights reserved.
+@REM Copyright (c) 2009-2017 Hitachi Vantara.  All rights reserved.
 
 REM ${project.name}
 REM ${project.version}.${build.number}

--- a/package-res/metadata-editor.command
+++ b/package-res/metadata-editor.command
@@ -1,3 +1,18 @@
+# This program is free software; you can redistribute it and/or modify it under the
+# terms of the GNU Lesser General Public License, version 2.1 as published by the Free Software
+# Foundation.
+#
+# You should have received a copy of the GNU Lesser General Public License along with this
+# program; if not, you can obtain a copy at http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html
+# or from the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+# without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See the GNU Lesser General Public License for more details.
+#
+# Copyright (c) 2013-2017 Hitachi Vantara.  All rights reserved.
+
 cd `dirname $0`
 
 # if a BASE_DIR argument has been passed to this .command, use it

--- a/package-res/set-pentaho-env.bat
+++ b/package-res/set-pentaho-env.bat
@@ -12,7 +12,7 @@
 @REM without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
 @REM See the GNU Lesser General Public License for more details.
 @REM
-@REM Copyright (c) 2010-2017 Pentaho Corporation..  All rights reserved.
+@REM Copyright (c) 2010-2017 Hitachi Vantara.  All rights reserved.
 
 rem ---------------------------------------------------------------------------
 rem Finds a suitable Java


### PR DESCRIPTION
- license was added
- Copyright was updated in missed scripts