### PR TITLE
[BACKLOG-27567] Remove org.osgi.core version override

### DIFF
--- a/assemblies/pme-ce/pom.xml
+++ b/assemblies/pme-ce/pom.xml
@@ -103,12 +103,9 @@
     <!-- OSGi Dependencies -->
     <!-- Because of: -->
     <!-- pdi-osgi-bridge-core (KarafLifecycleListener and OSGIPluginRegistryExtension) -->
-    <!-- Also, we are explicitly overriding OSGi core to 5.0.0 because of the org.osgi.framework.wiring.BundleWire.getProvider() method, -->
-    <!-- as Felix Framework 4.2.1 is partially OSGi 5.0 complaint. -->
     <dependency>
        <groupId>org.osgi</groupId>
        <artifactId>org.osgi.core</artifactId>
-       <version>5.0.0</version>
        <scope>runtime</scope>
     </dependency>
   </dependencies>


### PR DESCRIPTION
Merge after https://github.com/pentaho/maven-parent-poms/pull/105.
@graimundo please review.