### PR TITLE
[PPP-4448] Use of Vulnerable Component - XStream 1.4.10

### DIFF
--- a/editor/pom.xml
+++ b/editor/pom.xml
@@ -13,6 +13,12 @@
 
   <dependencies>
     <dependency>
+      <groupId>org.pentaho</groupId>
+      <artifactId>pentaho-metadata</artifactId>
+      <version>${pentaho-metadata.version}</version>
+    </dependency>
+
+    <dependency>
       <groupId>org.dom4j</groupId>
       <artifactId>dom4j</artifactId>
     </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -65,9 +65,6 @@
     <simple-jndi.version>0.11.1</simple-jndi.version>
     <snmp4j.version>1.9.3d</snmp4j.version>
     <trilead-ssh2.version>1.0.0-build215</trilead-ssh2.version>
-    <xmlpull.version>1.1.3.1</xmlpull.version>
-    <xpp3_min.version>1.1.4c</xpp3_min.version>
-    <xstream.version>1.4.10</xstream.version>
 
     <pentaho-connections.version>9.0.0.0-SNAPSHOT</pentaho-connections.version>
     <pdi.version>9.0.0.0-SNAPSHOT</pdi.version>
@@ -272,17 +269,6 @@
       </exclusions>
     </dependency>
     <dependency>
-      <groupId>org.pentaho</groupId>
-      <artifactId>pentaho-metadata</artifactId>
-      <version>${pentaho-metadata.version}</version>
-      <exclusions>
-        <exclusion>
-          <groupId>*</groupId>
-          <artifactId>*</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
-    <dependency>
       <groupId>pentaho-kettle</groupId>
       <artifactId>kettle-engine</artifactId>
       <version>${pdi.version}</version>
@@ -441,40 +427,6 @@
       <groupId>javax.ws.rs</groupId>
       <artifactId>jsr311-api</artifactId>
       <version>${jsr311-api.version}</version>
-      <exclusions>
-        <exclusion>
-          <groupId>*</groupId>
-          <artifactId>*</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
-
-    <dependency>
-      <groupId>xmlpull</groupId>
-      <artifactId>xmlpull</artifactId>
-      <version>${xmlpull.version}</version>
-      <exclusions>
-        <exclusion>
-          <groupId>*</groupId>
-          <artifactId>*</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
-    <dependency>
-      <groupId>xpp3</groupId>
-      <artifactId>xpp3_min</artifactId>
-      <version>${xpp3_min.version}</version>
-      <exclusions>
-        <exclusion>
-          <groupId>*</groupId>
-          <artifactId>*</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
-    <dependency>
-      <groupId>com.thoughtworks.xstream</groupId>
-      <artifactId>xstream</artifactId>
-      <version>${xstream.version}</version>
       <exclusions>
         <exclusion>
           <groupId>*</groupId>


### PR DESCRIPTION
This is part of a series of PRs. See https://github.com/pentaho/maven-parent-poms/pull/170 for details.

**Don't merge before the PR above.**

Moved `pentaho-metadata` dependency to where it is needed. Reorganized transitive dependencies. No need for exclusions in `pentaho-metadata`, those transitive dependencies end up in the final assembly from other dependencies.