### PR TITLE
[BACKLOG-33104] - Copyright needs to be updated to 2020 on 'Info.plis…

### DIFF
--- a/assemblies/pme-ce/src/main/resources/Metadata Editor.app/Contents/Info.plist
+++ b/assemblies/pme-ce/src/main/resources/Metadata Editor.app/Contents/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleDevelopmentRegion</key>
 	<string>English</string>
 	<key>CFBundleGetInfoString</key>
-	<string>Pentaho Metadata Editor 8.3 Copyright (c) 2008 - 2019 Hitachi Vantara</string>	
+	<string>Pentaho Metadata Editor 9.0 Copyright (c) 2008 - 2020 Hitachi Vantara</string>
 	<key>CFBundleExecutable</key>
 	<string>JavaApplicationStub</string>
 	<key>CFBundleIconFile</key>


### PR DESCRIPTION
…t' for each client tool

@pentaho/millenniumfalcon 