### PR TITLE
[PPP-4486] Use of Vulnerable Component: commons-codec [Multiple Versi…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,6 @@
     <blueprints-core.version>2.6.0</blueprints-core.version>
     <com.sun.jersey.version>1.19.1</com.sun.jersey.version>
     <commands.version>3.3.0-I20070605-0010</commands.version>
-    <commons-codec.version>1.10</commons-codec.version>
     <commons-collections.version>3.2.2</commons-collections.version>
     <commons-configuration.version>1.9</commons-configuration.version>
     <commons-io.version>2.2</commons-io.version>
@@ -127,17 +126,6 @@
       <groupId>commons-collections</groupId>
       <artifactId>commons-collections</artifactId>
       <version>${commons-collections.version}</version>
-      <exclusions>
-        <exclusion>
-          <groupId>*</groupId>
-          <artifactId>*</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
-    <dependency>
-      <groupId>commons-codec</groupId>
-      <artifactId>commons-codec</artifactId>
-      <version>${commons-codec.version}</version>
       <exclusions>
         <exclusion>
           <groupId>*</groupId>


### PR DESCRIPTION
…ons] (sonatype-2012-0050)

Bumping `commons-codec` to version 1.14 to address multiple CVEs.
Moving dependency management to the parent POMs.
Removing unnecessary dependencies.

Please see https://github.com/pentaho/maven-parent-poms/pull/214 for details.