### PR TITLE
[BACKLOG-40978] 10.2: Default driver class used is org.gjt.mm.mysql.driver instead of recommended com.mysql.jdbc.Driver

### DIFF
--- a/assemblies/pme-ce/src/main/resources/jdbc/MySQL.properties
+++ b/assemblies/pme-ce/src/main/resources/jdbc/MySQL.properties
@@ -4,7 +4,7 @@
 org.netbeans.mdr.storagemodel.StorageFactoryClassName=org.netbeans.mdr.persistence.jdbcimpl.JdbcStorageFactory
 
 # JDBC driver for MySQL
-MDRStorageProperty.org.netbeans.mdr.persistence.jdbcimpl.driverClassName=org.gjt.mm.mysql.Driver
+MDRStorageProperty.org.netbeans.mdr.persistence.jdbcimpl.driverClassName=com.mysql.jdbc.Driver
 
 # URL for database storage
 MDRStorageProperty.org.netbeans.mdr.persistence.jdbcimpl.url=jdbc:mysql://localhost:3306/CWM?defaultFetchSize=500&useCursorFetch=true


### PR DESCRIPTION
[BACKLOG-40978] 10.2: Default driver class used is org.gjt.mm.mysql.driver instead of recommended com.mysql.jdbc.Driver

[BACKLOG-40978]: https://hv-eng.atlassian.net/browse/BACKLOG-40978?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ