### PR TITLE
[BACKLOG-43109] Pentaho Business Analytics and Reporting tools End us…

### DIFF
--- a/LICENSE.TXT
+++ b/LICENSE.TXT
@@ -1,4 +1,4 @@
-Pentaho Developer Edition 10.3 Copyright 2024 Hitachi Vantara, LLC; licensed under the
+Pentaho Developer Edition 10.3 Copyright 2025 Hitachi Vantara, LLC; licensed under the
 Business Source License 1.1 (BSL). This project may include third party components that
 are individually licensed per the terms indicated by their respective copyright owners
 included in text file or in the source code. 
@@ -9,7 +9,7 @@ License text copyright (c) 2020 MariaDB Corporation Ab, All Rights Reserved.
 Parameters
 
 Licensor:             Hitachi Vantara, LLC.
-Licensed Work:        Pentaho Developer Edition 10.3. The Licensed Work is (c) 2024
+Licensed Work:        Pentaho Developer Edition 10.3. The Licensed Work is (c) 2025
                       Hitachi Vantara, LLC.
 Additional Use Grant: None
 Change Date:          Four years from the date the Licensed Work is published.


### PR DESCRIPTION
…er license Copyright year is 2002-2024, 2024 has to be updated to 2025 [EE and CE versions]