### PR TITLE
[BACKLOG-43118] In Mac Ventura, not able to use PME

### DIFF
--- a/editor/src/main/java/org/pentaho/pms/ui/MetaEditor.java
+++ b/editor/src/main/java/org/pentaho/pms/ui/MetaEditor.java
@@ -3705,10 +3705,6 @@ public class MetaEditor implements SelectionListener {
       }
     }
 
-    if ( !Splash.isMacOS() ) {
-      splash.hide();
-    }
-
     win.open();
     while ( !win.isDisposed() ) {
       if ( !win.readAndDispatch() ) {

--- a/editor/src/main/java/org/pentaho/pms/ui/util/AboutDialog.java
+++ b/editor/src/main/java/org/pentaho/pms/ui/util/AboutDialog.java
@@ -10,69 +10,20 @@
  * Change Date: 2028-08-13
  ******************************************************************************/
 
- package org.pentaho.pms.ui.util;
+package org.pentaho.pms.ui.util;
 
- import org.eclipse.swt.SWT;
- import org.eclipse.swt.events.MouseEvent;
- import org.eclipse.swt.events.MouseListener;
- import org.eclipse.swt.events.MouseMoveListener;
- import org.eclipse.swt.widgets.Dialog;
- import org.eclipse.swt.widgets.Shell;
- 
- 
- public class AboutDialog extends Dialog {
- 
-   private boolean blnMouseDown = false;
-   private boolean blnMouseMoveInProgress = false;
-   private int xPos = 0;
-   private int yPos = 0;
- 
-   public AboutDialog( Shell parent ) {
-     super( parent );
-   }
- 
-   public void open() throws Exception {
+import org.eclipse.swt.SWT;
+import org.eclipse.swt.widgets.Dialog;
+import org.eclipse.swt.widgets.Shell;
 
-     Shell splashShell = new Shell( getParent(), SWT.APPLICATION_MODAL + SWT.RESIZE );
-     final Splash splash = new Splash( getParent().getDisplay(), splashShell );
+public class AboutDialog extends Dialog {
 
-     splashShell.addMouseListener( new MouseListener() {
- 
-       @Override
-       public void mouseUp( MouseEvent arg0 ) {
-         if ( blnMouseMoveInProgress ) {
-           blnMouseDown = false;
-           blnMouseMoveInProgress = false;
-         } else {
-           splash.dispose();
-         }
-       }
- 
-       @Override
-       public void mouseDown( MouseEvent e ) {
-         blnMouseDown = true;
-         xPos = e.x;
-         yPos = e.y;
-       }
- 
-       @Override
-       public void mouseDoubleClick( MouseEvent arg0 ) {
-       }
- 
-     } );
- 
-     splashShell.addMouseMoveListener( new MouseMoveListener() {
- 
-       @Override
-       public void mouseMove( MouseEvent e ) {
-         // TODO Auto-generated method stub
-         if ( blnMouseDown ) {
-           blnMouseMoveInProgress = true;
-           splashShell.setLocation( splashShell.getLocation().x + ( e.x - xPos ),
-             splashShell.getLocation().y + ( e.y - yPos ) );
-         }
-       }
-     } );
-   }
- 
- }
+  public AboutDialog( Shell parent ) {
+    super( parent );
+  }
+
+  public void open() throws Exception {
+    Shell splashShell = new Shell( getParent(), SWT.APPLICATION_MODAL + SWT.RESIZE );
+    new Splash( getParent().getDisplay(), splashShell );
+  }
+}

--- a/editor/src/main/java/org/pentaho/pms/ui/util/Splash.java
+++ b/editor/src/main/java/org/pentaho/pms/ui/util/Splash.java
@@ -14,20 +14,19 @@
 package org.pentaho.pms.ui.util;
 
 import java.io.BufferedReader;
-import java.io.FileNotFoundException;
 import java.io.FileReader;
 import java.io.IOException;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Date;
-import java.util.Timer;
-import java.util.TimerTask;
 
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.eclipse.swt.SWT;
+import org.eclipse.swt.events.MouseEvent;
+import org.eclipse.swt.events.MouseListener;
 import org.eclipse.swt.graphics.Color;
 import org.eclipse.swt.graphics.Font;
 import org.eclipse.swt.graphics.FontData;
@@ -42,40 +41,124 @@ import org.pentaho.pms.ui.locale.Messages;
 
 /**
  * Displays the splash and about screen
- *
  */
 public class Splash {
 
   private static final Log logger = LogFactory.getLog( Splash.class );
 
   private static final String FONT_TYPE = "Helvetica";
-
   private static final String LICENSE_FILE_PATH = "./LICENSE.TXT";
+
+  private boolean isStartup;
+  private boolean isMouseDown = false;
+  private boolean isMouseMoveInProgress = false;
+  private int xPos = 0;
+  private int yPos = 0;
 
   private Shell shell;
   private Font verFont;
   private Font licFont;
+  private Display display;
+  private Image aboutScreenImage;
 
   private int textHorizontalPosition = 300;
 
 
   public Splash( Display display ) {
-    this( display, new Shell( display, SWT.APPLICATION_MODAL ) );
+    this( display, new Shell( display, SWT.APPLICATION_MODAL ), true );
   }
 
   protected Splash( Display display, Shell splashShell ) {
+    this( display, splashShell, false );
+  }
 
-    Rectangle displayBounds = display.getPrimaryMonitor().getBounds();
+  protected Splash( Display display, Shell splashShell, boolean isStartup ) {
+    this.display = display;
+    this.isStartup = isStartup;
 
     verFont = new Font( display, FONT_TYPE, 14, SWT.BOLD );
 
     shell = splashShell;
 
-    Image aboutScreenImage = GUIResource.getInstance().getImageMetaSplash();
+    aboutScreenImage = GUIResource.getInstance().getImageMetaSplash();
     shell.setImage( aboutScreenImage );
-
     shell.setText( Messages.getString( "MetaEditor.USER_HELP_METADATA_EDITOR" ) );
 
+    setupShellDimensions();
+
+    setupShellListeners();
+
+    shell.open();
+
+    if ( isStartup ) { //show splash for 5s on startup
+      long endTime = System.currentTimeMillis() + 5000;
+      while ( !shell.isDisposed() && endTime > System.currentTimeMillis() ) {
+        if ( isMacOS() && !display.readAndDispatch() ) {
+          display.sleep();
+        }
+      }
+      shell.dispose();
+    }
+  }
+
+  private void setupShellDimensions() {
+    Rectangle displayBounds = display.getPrimaryMonitor().getBounds();
+    Rectangle bounds = aboutScreenImage.getBounds();
+    int x = ( displayBounds.width - bounds.width ) / 2;
+    int y = ( displayBounds.height - bounds.height ) / 2;
+
+    shell.setSize( bounds.width, bounds.height );
+    shell.setLocation( x, y );
+  }
+
+  private void setupShellListeners() {
+    setupShellPaintListener();
+
+    shell.addMouseListener( new MouseListener() {
+
+      @Override
+      public void mouseUp( MouseEvent e ) {
+        if ( isMouseMoveInProgress ) {
+          isMouseDown = false;
+          isMouseMoveInProgress = false;
+        } else {
+          shell.dispose();
+        }
+      }
+
+      @Override
+      public void mouseDown( MouseEvent e ) {
+        isMouseDown = true;
+        xPos = e.x;
+        yPos = e.y;
+      }
+
+      @Override public void mouseDoubleClick( MouseEvent mouseEvent ) {
+        // Do Nothing
+      }
+
+    } );
+    shell.addMouseMoveListener( e -> {
+      if ( isMouseDown ) {
+        isMouseMoveInProgress = true;
+        shell.setLocation( shell.getLocation().x + ( e.x - xPos ),
+          shell.getLocation().y + ( e.y - yPos ) );
+      }
+    } );
+
+    shell.addDisposeListener( disposeEvent -> {
+
+      //dispose of the image only once the program is closed
+      if ( !isStartup && ( (Shell) disposeEvent.widget ).getParent() == null ) {
+        aboutScreenImage.dispose();
+      }
+      verFont.dispose();
+      licFont.dispose();
+
+    } );
+  }
+
+  private void setupShellPaintListener() {
     shell.addPaintListener( e -> {
 
       e.gc.drawImage( aboutScreenImage, 0, 0 );
@@ -83,7 +166,8 @@ public class Splash {
       String fullVersionText = Messages.getString( "MetaEditor.USER_HELP_VERSION" );
       String buildVersion = BuildVersion.getInstance().getVersion();
       if ( StringUtils.ordinalIndexOf( buildVersion, ".", 2 ) > 0 ) {
-        fullVersionText = fullVersionText + " " + buildVersion.substring( 0, StringUtils.ordinalIndexOf( buildVersion, ".", 2 ) );
+        fullVersionText =
+          fullVersionText + " " + buildVersion.substring( 0, StringUtils.ordinalIndexOf( buildVersion, ".", 2 ) );
       } else {
         fullVersionText = fullVersionText + " " + buildVersion;
       }
@@ -135,7 +219,7 @@ public class Splash {
       String line;
       try {
         BufferedReader reader =
-          new BufferedReader( new FileReader( LICENSE_FILE_PATH ));
+          new BufferedReader( new FileReader( LICENSE_FILE_PATH ) );
 
         while ( ( line = reader.readLine() ) != null ) {
           sb.append( line + System.getProperty( "line.separator" ) );
@@ -148,7 +232,7 @@ public class Splash {
 
       // try using the desired font size for the license text
       java.util.List<String> fontsAvailable = new ArrayList<String>();
-      for ( FontData fontData : display.getFontList(null, true) ) {
+      for ( FontData fontData : display.getFontList( null, true ) ) {
         fontsAvailable.add( fontData.getName() );
       }
 
@@ -193,58 +277,12 @@ public class Splash {
       e.gc.drawText( licenseText, textHorizontalPosition, 150, true );
 
     } );
-
-
-    shell.addDisposeListener( disposeEvent -> {
-
-      //dispose of the image only once the program is closed
-      if( ( (Shell) disposeEvent.widget ).getParent() == null ) {
-        aboutScreenImage.dispose();
-      }
-      verFont.dispose();
-      licFont.dispose();
-
-    } );
-
-
-    Rectangle bounds = aboutScreenImage.getBounds();
-    int x = ( displayBounds.width - bounds.width ) / 2;
-    int y = ( displayBounds.height - bounds.height ) / 2;
-
-    shell.setSize( bounds.width, bounds.height );
-    shell.setLocation( x, y );
-
-    shell.open();
-
-    if ( isMacOS() ) {  // This forces the splash screen to display on the Mac.
-      long endTime = System.currentTimeMillis() + 5000; // 5 second delay... can you read the splash that fast?
-      while ( !shell.isDisposed() && endTime > System.currentTimeMillis() ) {
-        if ( !display.readAndDispatch() ) {
-          display.sleep();
-        }
-      }
-    }
-
-    TimerTask timerTask = new TimerTask() {
-
-      @Override
-      public void run() {
-        try {
-          shell.redraw();
-        } catch ( Throwable e ) {
-          // ignore.
-        }
-      }
-
-    };
-
-    final Timer timer = new Timer();
-    timer.schedule( timerTask, 0, 100 );
-
-    shell.addDisposeListener( arg0 -> timer.cancel() );
-
   }
 
+  public static boolean isMacOS() {
+    String osName = System.getProperty( "os.name" ).toLowerCase();
+    return osName.startsWith( "mac os x" );
+  }
 
   // determine if the license text will fit the allocated space
   private boolean willLicenseTextFit( String licenseText, GC gc ) {
@@ -259,123 +297,5 @@ public class Splash {
     boolean fitsHorizontally = height >= requiredSize.y;
 
     return ( fitsVertically && fitsHorizontally );
-
-  }
-
-  public void dispose() {
-    if ( !shell.isDisposed() ) {
-      shell.dispose();
-    }
-  }
-
-  public void hide() {
-    if ( !shell.isDisposed() ) {
-      shell.setVisible( false );
-    }
-  }
-
-  public void show() {
-    if ( !shell.isDisposed() ) {
-      shell.setVisible( true );
-    }
-  }
-
-  public static boolean isMacOS() {
-    String osName = System.getProperty( "os.name" ).toLowerCase();
-    return osName.startsWith( "mac os x" );
-  }
-
-}
-/*
-  public Splash( final Display display ) {
-    Rectangle displayBounds = display.getPrimaryMonitor().getBounds();
-
-    final Image splashImage = GUIResource.getInstance().getImageMetaSplash();
-    final Image splashIcon = GUIResource.getInstance().getImageIcon();
-
-    splash = new Shell( display, SWT.NONE );
-    splash.setImage( splashIcon );
-    splash.setText( Messages.getString( "Splash.USER_APP_TITLE" ) ); //$NON-NLS-1$
-
-
-    FormLayout splashLayout = new FormLayout();
-    splash.setLayout( splashLayout );
-
-    Control above = splash;
-    int left = 290;
-
-    VersionHelper helper = new VersionHelper();
-    Label versionLbl = new Label( splash, SWT.NONE );
-    above = placeBelow( versionLbl, above, left, 160 );
-
-    versionLbl.setFont( new Font( splash.getDisplay(), "Sans", 10, SWT.BOLD ) );
-    versionLbl.setText( Messages.getString( "Splash.VERSION_INFO", helper.getVersionInformation( Splash.class, false ) ) );
-    Label copyrightLbl1 = new Label( splash, SWT.NONE );
-    above = placeBelow( copyrightLbl1, above, left, 5 );
-
-    String year = "" + LocalDateTime.now().getYear();
-    copyrightLbl1.setText( Messages.getString( "MetaEditor.USER_HELP_PENTAHO_CORPORATION", year ) );
-    Font copyrightFont = new Font( splash.getDisplay(), "Sans", 8, SWT.NONE );
-    copyrightLbl1.setFont( copyrightFont );
-
-    splash.setBackgroundImage( splashImage );
-    splash.setBackgroundMode( SWT.INHERIT_DEFAULT );
-    Link license = new Link( splash, SWT.NONE );
-    license.setText( Messages.getString( "Splash.LICENSE" ) );
-    license.setFont( new Font( splash.getDisplay(), "Sans", 9, SWT.NONE  ) );
-
-    above = placeBelow( license, above, left, 10 );
-
-    splash.addDisposeListener( new DisposeListener() {
-      public void widgetDisposed( DisposeEvent arg0 ) {
-        splashImage.dispose();
-      }
-    } );
-    Rectangle bounds = splashImage.getBounds();
-    int x = ( displayBounds.width - bounds.width ) / 2;
-    int y = ( displayBounds.height - bounds.height ) / 2;
-
-    splash.setSize( bounds.width, bounds.height );
-    splash.setLocation( x, y );
-
-    splash.open();
-
-    if ( isMacOS() ) {
-      long endTime = System.currentTimeMillis() + 5000; // 5 second delay... can you read the splash that fast?
-      while ( splash != null && !splash.isDisposed() && endTime > System.currentTimeMillis() ) {
-        if ( !display.readAndDispatch() ) {
-          display.sleep();
-        }
-      }
-      splash.close();
-    }
-  }
-
-  private static Control placeBelow( Control toPlace, Control above, int x, int yOffset ) {
-    FormData fd = new FormData();
-    fd.left = new FormAttachment( 0, x );
-    fd.top = new FormAttachment( above, yOffset );
-    toPlace.setLayoutData( fd );
-    return toPlace;
-  }
-
-  public void dispose() {
-    if ( !splash.isDisposed() ) {
-      splash.dispose();
-    }
-  }
-
-  public void hide() {
-    splash.setVisible( false );
-  }
-
-  public void show() {
-    splash.setVisible( true );
-  }
-
-  public static boolean isMacOS() {
-    String osName = System.getProperty( "os.name" ).toLowerCase();
-    return osName.startsWith( "mac os x" );
   }
 }
-  */


### PR DESCRIPTION
- The timer logic was broken for all OSes (Windows, Ubuntu, Mac). It wasn't showing the splash on startup for Windows and Ubuntu, and on Mac you got hard locked into a sleep cycle and the application was unresponsive
- Fixed and unified timer logic to show Splash for 5s on startup for all OS
- Removed giant comment at end of Splash file, we have source control for that
- Moved all handlers from AboutDialog back to the Splash, AboutDialog is just a different way to open the Splash page with the main metadata editor as its parent -- In this way we can distinguish how the dialog has been opened and is being closed, for the startup Splash and the AboutDialog splash we are using the parent widget to determine how it was closed to preserve the splash image until the final application close, a fix made in https://github.com/pentaho/pentaho-metadata-editor/commit/cc761af9512a897433fbb680a7de7abdda0dd0ec#diff-a8c2f197cd7af3571442867700a4232f32b70a58963a69acbac9167e85f2f539R205