### PR TITLE
[BACKLOG-40823] - Upgrade the Tomcat version from current to 10.x.x with Java 17

### DIFF
--- a/assemblies/pme-ce/pom.xml
+++ b/assemblies/pme-ce/pom.xml
@@ -271,6 +271,62 @@
               </artifactItems>
             </configuration>
           </execution>
+          <execution>
+            <!--
+              Dependencies for Javax XML Binding API, JAXB Runtime, Javax Activation API, Javax Transaction API and IStack Commons Runtime
+              These dependencies are required for OSGi environment and Felix directly depends on javax.xml.bind (Javax XML Bind API and Javax JAXB runtime) and we are making these available to OSGi through jre.properties.
+              Even if these dependencies are added to pom.xml dependencies section, maven is trying to add the latest version of artifacts instead of adding jars with both versions.
+              So, Following configuration helps to copy the both versions of jars to the lib.
+             -->
+            <id>copy-extra-dependencies</id>
+            <phase>generate-resources</phase>
+            <goals>
+              <goal>copy</goal>
+            </goals>
+            <configuration>
+              <outputDirectory>${project.build.directory}/libs/libext/pentaho</outputDirectory>
+              <artifactItems>
+                <artifactItem>
+                  <groupId>jakarta.xml.bind</groupId>
+                  <artifactId>jakarta.xml.bind-api</artifactId>
+                  <version>${jakarta.xml.bind-api.version}</version>
+                  <type>jar</type>
+                </artifactItem>
+                <artifactItem>
+                  <groupId>jakarta.xml.bind</groupId>
+                  <artifactId>jakarta.xml.bind-api</artifactId>
+                  <version>${jakarta.xml.bind-osgi.version}</version>
+                  <type>jar</type>
+                </artifactItem>
+
+                <artifactItem>
+                  <groupId>org.glassfish.jaxb</groupId>
+                  <artifactId>jaxb-runtime</artifactId>
+                  <version>${jaxb-api-osgi.version}</version>
+                  <type>jar</type>
+                </artifactItem>
+
+                <artifactItem>
+                  <groupId>jakarta.transaction</groupId>
+                  <artifactId>jakarta.transaction-api</artifactId>
+                  <version>${jakarta.transaction-api-osgi.version}</version>
+                  <type>jar</type>
+                </artifactItem>
+
+                <artifactItem>
+                  <groupId>jakarta.activation</groupId>
+                  <artifactId>jakarta.activation-api</artifactId>
+                  <version>${jakarta.activation-osgi.version}</version>
+                </artifactItem>
+
+                <artifactItem>
+                  <groupId>com.sun.istack</groupId>
+                  <artifactId>istack-commons-runtime</artifactId>
+                  <version>${istack-osgi.version}</version>
+                </artifactItem>
+              </artifactItems>
+            </configuration>
+          </execution>
         </executions>
       </plugin>
       <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,6 @@
 
   <properties>
     <blueprints-core.version>2.6.0</blueprints-core.version>
-    <com.sun.jersey.version>1.19.1</com.sun.jersey.version>
     <commons-collections.version>3.2.2</commons-collections.version>
     <commons-configuration.version>1.9</commons-configuration.version>
     <commons-lang.version>2.6</commons-lang.version>
@@ -326,9 +325,9 @@
       <version>${mimepull.version}</version>
     </dependency>
     <dependency>
-      <groupId>com.sun.jersey.contribs</groupId>
-      <artifactId>jersey-multipart</artifactId>
-      <version>${com.sun.jersey.version}</version>
+      <groupId>org.glassfish.jersey.media</groupId>
+      <artifactId>jersey-media-multipart</artifactId>
+      <version>${jersey.version}</version>
       <exclusions>
         <exclusion>
           <groupId>*</groupId>
@@ -337,9 +336,9 @@
       </exclusions>
     </dependency>
     <dependency>
-      <groupId>com.sun.jersey.contribs</groupId>
-      <artifactId>jersey-apache-client</artifactId>
-      <version>${com.sun.jersey.version}</version>
+      <groupId>org.glassfish.jersey.ext</groupId>
+      <artifactId>jersey-spring6</artifactId>
+      <version>${jersey.version}</version>
       <exclusions>
         <exclusion>
           <groupId>*</groupId>
@@ -348,43 +347,9 @@
       </exclusions>
     </dependency>
     <dependency>
-      <groupId>com.sun.jersey.contribs</groupId>
-      <artifactId>jersey-spring</artifactId>
-      <version>${com.sun.jersey.version}</version>
-      <exclusions>
-        <exclusion>
-          <groupId>*</groupId>
-          <artifactId>*</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
-
-    <dependency>
-      <groupId>com.sun.jersey</groupId>
-      <artifactId>jersey-core</artifactId>
-      <version>${com.sun.jersey.version}</version>
-      <exclusions>
-        <exclusion>
-          <groupId>*</groupId>
-          <artifactId>*</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
-    <dependency>
-      <groupId>com.sun.jersey</groupId>
-      <artifactId>jersey-json</artifactId>
-      <version>${com.sun.jersey.version}</version>
-      <exclusions>
-        <exclusion>
-          <groupId>*</groupId>
-          <artifactId>*</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
-    <dependency>
-      <groupId>com.sun.jersey</groupId>
+      <groupId>org.glassfish.jersey.core</groupId>
       <artifactId>jersey-client</artifactId>
-      <version>${com.sun.jersey.version}</version>
+      <version>${jersey.version}</version>
       <exclusions>
         <exclusion>
           <groupId>*</groupId>
@@ -393,9 +358,9 @@
       </exclusions>
     </dependency>
     <dependency>
-      <groupId>com.sun.jersey</groupId>
+      <groupId>org.glassfish.jersey.core</groupId>
       <artifactId>jersey-server</artifactId>
-      <version>${com.sun.jersey.version}</version>
+      <version>${jersey.version}</version>
       <exclusions>
         <exclusion>
           <groupId>*</groupId>
@@ -404,9 +369,9 @@
       </exclusions>
     </dependency>
     <dependency>
-      <groupId>com.sun.jersey</groupId>
-      <artifactId>jersey-servlet</artifactId>
-      <version>${com.sun.jersey.version}</version>
+      <groupId>org.glassfish.jersey.containers</groupId>
+      <artifactId>jersey-container-servlet</artifactId>
+      <version>${jersey.version}</version>
       <exclusions>
         <exclusion>
           <groupId>*</groupId>
@@ -415,9 +380,9 @@
       </exclusions>
     </dependency>
     <dependency>
-      <groupId>javax.ws.rs</groupId>
-      <artifactId>jsr311-api</artifactId>
-      <version>${jsr311-api.version}</version>
+      <groupId>jakarta.ws.rs</groupId>
+      <artifactId>jakarta.ws.rs-api</artifactId>
+      <version>${jakarta.ws.rs-api.version}</version>
       <exclusions>
         <exclusion>
           <groupId>*</groupId>


### PR DESCRIPTION
This pull request includes changes to migrate the project from the legacy `com.sun.jersey` library to the modern `org.glassfish.jersey` and `jakarta.ws.rs` libraries. Additionally, it introduces new Maven configurations to handle dependencies required for OSGi environments.

### Migration to modern libraries:

* [`editor/src/main/java/org/pentaho/pms/ui/dialog/PublishDialog.java`](diffhunk://#diff-bb7e5eed6d896cf8ccec615943df3aeb55f3342fbe12d6616e03ae17cb1d0c89L16-R24): Replaced imports and updated code to use `jakarta.ws.rs` and `org.glassfish.jersey` libraries instead of `com.sun.jersey`. This includes changes to authentication, HTTP requests, and response handling. [[1]](diffhunk://#diff-bb7e5eed6d896cf8ccec615943df3aeb55f3342fbe12d6616e03ae17cb1d0c89L16-R24) [[2]](diffhunk://#diff-bb7e5eed6d896cf8ccec615943df3aeb55f3342fbe12d6616e03ae17cb1d0c89L42-R45) [[3]](diffhunk://#diff-bb7e5eed6d896cf8ccec615943df3aeb55f3342fbe12d6616e03ae17cb1d0c89L255-R272)
* [`pom.xml`](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8L329-R330): Removed dependencies on `com.sun.jersey` and replaced them with corresponding `org.glassfish.jersey` and `jakarta.ws.rs` dependencies. This includes updates for multipart handling, client configuration, and servlet containers. [[1]](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8L329-R330) [[2]](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8L340-R341) [[3]](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8L351-R352) [[4]](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8L396-R363) [[5]](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8L407-R374) [[6]](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8L418-R385)

### Maven configuration for OSGi dependencies:

* [`assemblies/pme-ce/pom.xml`](diffhunk://#diff-c33d9b1400542ecb9b841c8a6f7e565c20ffefa7e2349b743b1a9a8c3eddd127R274-R329): Added a new Maven execution to copy specific versions of dependencies required for OSGi environments, ensuring compatibility with Felix and other OSGi components. This configuration addresses issues with Maven's default behavior of selecting the latest artifact versions.