### PR TITLE
build[PDI-20311]: remove declaration of unused dependency trilead-ssh2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -61,7 +61,6 @@
     <pentaho-cwm.version>1.5.4</pentaho-cwm.version>
     <scannotation.version>1.0.2</scannotation.version>
     <snmp4j.version>1.9.3d</snmp4j.version>
-    <trilead-ssh2.version>1.0.0-build215</trilead-ssh2.version>
 
     <pentaho-connections.version>11.0.0.0-SNAPSHOT</pentaho-connections.version>
     <pdi.version>11.0.0.0-SNAPSHOT</pdi.version>
@@ -770,17 +769,6 @@
       <groupId>pentaho</groupId>
       <artifactId>simple-jndi</artifactId>
       <version>${simple-jndi.version}</version>
-      <exclusions>
-        <exclusion>
-          <groupId>*</groupId>
-          <artifactId>*</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
-    <dependency>
-      <groupId>com.trilead</groupId>
-      <artifactId>trilead-ssh2</artifactId>
-      <version>${trilead-ssh2.version}</version>
       <exclusions>
         <exclusion>
           <groupId>*</groupId>


### PR DESCRIPTION
Remove unused trilead-ssh2 dependency declarations

## Problem
The dependency trilead-ssh2 is declared in the pentaho-metadata-editor project:

- pom.xml defines the version property and dependencyManagement for trilead-ssh2.version

However, it's never declared in any sub-module.

## Solution
This PR removes all trilead-ssh2 dependency declarations from the affected POMs.

## Verification
- Confirmed no actual usage of trilead-ssh2 classes in the codebase via code search
- Verified all modules still compile successfully after removal
- Dependency analysis no longer reports trilead-ssh2 as unused

## Context
This cleanup is part of PDI-20311, where trilead-ssh2 will be replaced with other SSH client tools. Since this dependency is unused in the pentaho-metadata-editor project, it can be safely removed.