### PR TITLE
[BACKLOG-43902]-Java 21 : compatibility check for Pentaho and fix Build and Run time issues while building / testing

### DIFF
--- a/editor/pom.xml
+++ b/editor/pom.xml
@@ -76,13 +76,13 @@
     <dependency>
       <groupId>net.bytebuddy</groupId>
       <artifactId>byte-buddy-agent</artifactId>
-      <version>1.12.16</version>
+      <version>${byte-buddy.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>net.bytebuddy</groupId>
       <artifactId>byte-buddy</artifactId>
-      <version>1.12.16</version>
+      <version>${byte-buddy.version}</version>
       <scope>test</scope>
     </dependency>
   </dependencies>


### PR DESCRIPTION
This pull request makes a minor update to the `editor/pom.xml` file by replacing hardcoded `byte-buddy` dependency versions with the `${byte-buddy.version}` property. This change helps maintain consistency and simplifies version management for these dependencies.