### PR TITLE
fix: ensure error dialog doesn't close main dialog [PRD-6183]

### DIFF
--- a/editor/src/main/java/org/pentaho/pms/ui/QueryBuilderDialog.java
+++ b/editor/src/main/java/org/pentaho/pms/ui/QueryBuilderDialog.java
@@ -562,5 +562,16 @@ public class QueryBuilderDialog extends Dialog {
   public MQLQuery getMqlQuery(){
     return editor.getMqlQuery();
   }
-  
+
+  @Override
+  public void okPressed() {
+    // Ensure that if the getMqlQuery operation fails, an error message shows and the dialog is not closed
+    try {
+      getMqlQuery();
+      super.okPressed();
+    } catch ( Exception e ) {
+      new ErrorDialog( getParentShell(), Messages.getString( "General.USER_TITLE_ERROR" ),
+        Messages.getString( "QueryDialog.USER_ERROR_LOADING_QUERY" ), e );
+    }
+  }
 }

--- a/editor/src/main/java/org/pentaho/pms/ui/QueryBuilderDialog.java
+++ b/editor/src/main/java/org/pentaho/pms/ui/QueryBuilderDialog.java
@@ -564,14 +564,14 @@ public class QueryBuilderDialog extends Dialog {
   }
 
   @Override
-  public void okPressed() {
+  protected void okPressed() {
     // Ensure that if the getMqlQuery operation fails, an error message shows and the dialog is not closed
     try {
       getMqlQuery();
       super.okPressed();
     } catch ( Exception e ) {
-      new ErrorDialog( getParentShell(), Messages.getString( "General.USER_TITLE_ERROR" ),
-        Messages.getString( "QueryDialog.USER_ERROR_LOADING_QUERY" ), e );
+      new ErrorDialog( getShell(), Messages.getString( "General.USER_TITLE_ERROR" ),
+        Messages.getString( "QueryDialog.USER_ERROR_GENERATING_QUERY" ), e );
     }
   }
 }


### PR DESCRIPTION
Addresses PRD-6183 and PRD-6258

Ensures the error dialog does not close the MQL editor dialog when it is triggered after the user clicks the `OK` button.