### PR TITLE
build[SP-7261]: update Hibernate dependency configuration to use parent version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,6 @@
     <ehcache.version>1.1</ehcache.version>
     <equinox.bidi.version>1.3.0</equinox.bidi.version>
     <equinox.common.version>3.14.0</equinox.common.version>
-    <hibernate.version>5.4.24.Final</hibernate.version>
     <javadbf.version>0.4.0</javadbf.version>
     <javassist.version>3.20.0-GA</javassist.version>
     <jface.version>3.22.0</jface.version>
@@ -686,9 +685,9 @@
       </exclusions>
     </dependency>
     <dependency>
-      <groupId>org.hibernate</groupId>
+      <groupId>org.hibernate.orm</groupId>
       <artifactId>hibernate-core</artifactId>
-      <version>${hibernate.version}</version>
+      <version>${hibernate-core.version}</version>
       <exclusions>
         <exclusion>
           <groupId>*</groupId>


### PR DESCRIPTION
NOTE: This PR was created by Copilot automation.

## Backport Information
- **SP Issue:** [SP-7261 - Backport of PPP-6248 - (11.0 Suite) CVE-2026-0603 | pdia-master has a security violation in Hibernate](https://hv-eng.atlassian.net/browse/SP-7261)
- **Base Case:** [PPP-6248 - CVE-2026-0603 | pdia-master has a security violation in Hibernate](https://hv-eng.atlassian.net/browse/PPP-6248)
- **Original Master PR:** https://github.com/pentaho/pentaho-metadata-editor/pull/333

## Changes
- Cherry-picked PR #333 (build[PPP-6248]: update Hibernate dependency configuration to use parent version).
- Commit: 1b07c95098cb37efc807451c9a14b376ae67a01c

## Conflict Resolution
- No manual conflict resolution required

## Target
- **Target Branch:** 11.0 (11.0 Suite maintenance branch)
