### PR TITLE
CVE fix: CVE-2023-4218 in org.eclipse.platform:org.eclipse.jface

### DIFF
--- a/editor/src/test/java/org/pentaho/pms/security/JFaceCveRegressionTest.java
+++ b/editor/src/test/java/org/pentaho/pms/security/JFaceCveRegressionTest.java
@@ -13,12 +13,14 @@
 
 package org.pentaho.pms.security;
 
-import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 import java.io.InputStream;
 import java.net.URL;
+import java.util.ArrayList;
 import java.util.Enumeration;
+import java.util.List;
 import java.util.jar.Manifest;
 
 import org.junit.Test;
@@ -38,15 +40,20 @@ public class JFaceCveRegressionTest {
 
   @Test
   public void jfaceBundleIsAtOrAboveCveFixedVersion() throws Exception {
-    String bundleVersion = resolveJFaceBundleVersion();
-    assertNotNull( "org.eclipse.jface bundle was not found on the classpath", bundleVersion );
-    assertTrue(
-      "Vulnerable org.eclipse.jface " + bundleVersion
-        + " is below the CVE-2023-4218 fixed line (3.29.0); bump jface.version.",
-      compareToMinimum( bundleVersion ) >= 0 );
+    List<String> bundleVersions = resolveJFaceBundleVersions();
+    assertFalse( "org.eclipse.jface bundle was not found on the classpath", bundleVersions.isEmpty() );
+    // Check EVERY jface bundle on the classpath (order-independent): if any copy is below the
+    // fixed line the guard must fail, regardless of which one Maven resolution would win.
+    for ( String bundleVersion : bundleVersions ) {
+      assertTrue(
+        "Vulnerable org.eclipse.jface " + bundleVersion + " (all found: " + bundleVersions
+          + ") is below the CVE-2023-4218 fixed line (3.29.0); bump jface.version.",
+        compareToMinimum( bundleVersion ) >= 0 );
+    }
   }
 
-  private static String resolveJFaceBundleVersion() throws Exception {
+  private static List<String> resolveJFaceBundleVersions() throws Exception {
+    List<String> versions = new ArrayList<>();
     Enumeration<URL> manifests =
       JFaceCveRegressionTest.class.getClassLoader().getResources( "META-INF/MANIFEST.MF" );
     while ( manifests.hasMoreElements() ) {
@@ -54,11 +61,14 @@ public class JFaceCveRegressionTest {
         Manifest manifest = new Manifest( in );
         String symbolicName = manifest.getMainAttributes().getValue( "Bundle-SymbolicName" );
         if ( symbolicName != null && "org.eclipse.jface".equals( symbolicName.split( ";" )[ 0 ].trim() ) ) {
-          return manifest.getMainAttributes().getValue( "Bundle-Version" );
+          String version = manifest.getMainAttributes().getValue( "Bundle-Version" );
+          if ( version != null ) {
+            versions.add( version );
+          }
         }
       }
     }
-    return null;
+    return versions;
   }
 
   private static int compareToMinimum( String actualVersion ) {

--- a/editor/src/test/java/org/pentaho/pms/security/JFaceCveRegressionTest.java
+++ b/editor/src/test/java/org/pentaho/pms/security/JFaceCveRegressionTest.java
@@ -1,0 +1,82 @@
+/*! ******************************************************************************
+ *
+ * Pentaho
+ *
+ * Copyright (C) 2024 by Hitachi Vantara, LLC : http://www.pentaho.com
+ *
+ * Use of this software is governed by the Business Source License included
+ * in the LICENSE.TXT file.
+ *
+ * Change Date: 2029-07-20
+ ******************************************************************************/
+
+
+package org.pentaho.pms.security;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import java.io.InputStream;
+import java.net.URL;
+import java.util.Enumeration;
+import java.util.jar.Manifest;
+
+import org.junit.Test;
+
+/**
+ * Regression guard for CVE-2023-4218 (Eclipse JFace XXE, CWE-611).
+ *
+ * <p>Fails if the {@code org.eclipse.jface} bundle resolved on the classpath is older than the
+ * first fixed version on the current line (3.29.0). This encodes the remediation invariant so the
+ * vulnerable 3.22.0 cannot silently creep back via {@code jface.version}. RED on 3.22.0, GREEN on
+ * 3.31.0.</p>
+ */
+public class JFaceCveRegressionTest {
+
+  /** First fixed version on the current JFace line for CVE-2023-4218. */
+  private static final int[] MIN_FIXED_VERSION = { 3, 29, 0 };
+
+  @Test
+  public void jfaceBundleIsAtOrAboveCveFixedVersion() throws Exception {
+    String bundleVersion = resolveJFaceBundleVersion();
+    assertNotNull( "org.eclipse.jface bundle was not found on the classpath", bundleVersion );
+    assertTrue(
+      "Vulnerable org.eclipse.jface " + bundleVersion
+        + " is below the CVE-2023-4218 fixed line (3.29.0); bump jface.version.",
+      compareToMinimum( bundleVersion ) >= 0 );
+  }
+
+  private static String resolveJFaceBundleVersion() throws Exception {
+    Enumeration<URL> manifests =
+      JFaceCveRegressionTest.class.getClassLoader().getResources( "META-INF/MANIFEST.MF" );
+    while ( manifests.hasMoreElements() ) {
+      try ( InputStream in = manifests.nextElement().openStream() ) {
+        Manifest manifest = new Manifest( in );
+        String symbolicName = manifest.getMainAttributes().getValue( "Bundle-SymbolicName" );
+        if ( symbolicName != null && "org.eclipse.jface".equals( symbolicName.split( ";" )[ 0 ].trim() ) ) {
+          return manifest.getMainAttributes().getValue( "Bundle-Version" );
+        }
+      }
+    }
+    return null;
+  }
+
+  private static int compareToMinimum( String actualVersion ) {
+    String[] parts = actualVersion.split( "\\." );
+    for ( int i = 0; i < MIN_FIXED_VERSION.length; i++ ) {
+      int actual = i < parts.length ? leadingInt( parts[ i ] ) : 0;
+      if ( actual != MIN_FIXED_VERSION[ i ] ) {
+        return actual - MIN_FIXED_VERSION[ i ];
+      }
+    }
+    return 0;
+  }
+
+  private static int leadingInt( String value ) {
+    int end = 0;
+    while ( end < value.length() && Character.isDigit( value.charAt( end ) ) ) {
+      end++;
+    }
+    return end == 0 ? 0 : Integer.parseInt( value.substring( 0, end ) );
+  }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -31,14 +31,15 @@
     <commons-collections.version>3.2.2</commons-collections.version>
     <commons-configuration.version>1.9</commons-configuration.version>
     <commons-lang.version>2.6</commons-lang.version>
-    <core.commands.version>3.9.800</core.commands.version>
+    <!-- Eclipse UI libs bumped together to remediate CVE-2023-4218 (jface XXE); aligned with pentaho-kettle PPP-6529 (jface 3.31.0 / commands 3.12.100 / common 3.18.0). jface 3.31.0 requires equinox.common [3.18.0,4.0.0). -->
+    <core.commands.version>3.12.100</core.commands.version>
     <edtftpj.version>2.1.0</edtftpj.version>
     <ehcache.version>1.1</ehcache.version>
     <equinox.bidi.version>1.3.0</equinox.bidi.version>
-    <equinox.common.version>3.14.0</equinox.common.version>
+    <equinox.common.version>3.18.0</equinox.common.version>
     <javadbf.version>0.4.0</javadbf.version>
     <javassist.version>3.20.0-GA</javassist.version>
-    <jface.version>3.22.0</jface.version>
+    <jface.version>3.31.0</jface.version>
     <jsr311-api.version>1.1.1</jsr311-api.version>
     <jug-lgpl.version>2.0.0</jug-lgpl.version>
     <junit.version>4.13.2</junit.version>


### PR DESCRIPTION
## CVE fix: CVE-2023-4218 in org.eclipse.platform:org.eclipse.jface

Tracking: [PPP-6529](https://pentaho-eng.atlassian.net/browse/PPP-6529)
Advisory: CVE-2023-4218 / GHSA-j24h-xcpc-9jw8 -- Medium (CWE-611, XXE)
Change: `org.eclipse.platform:org.eclipse.jface` 3.22.0 -> 3.31.0
Fix point: version properties in the root `pom.xml` (jface/commands/common/bidi are direct deps with wildcard transitive exclusions; the `assemblies` module ships them into the PME `libext`).

Leftover companion to pentaho/pentaho-metadata-editor-ee#206 — the CE metadata editor carries the same vulnerable jface 3.22.0 that pentaho-kettle PPP-6529 already remediated platform-wide.

### Why 3.31.0 (not 3.29.0)
Aligned with **pentaho-kettle PPP-6529** (PR #10537), which standardized the platform on `jface 3.31.0 / core.commands 3.12.100 / equinox.common 3.18.0`. `equinox.common` **must** move to >= 3.18.0 because `org.eclipse.jface 3.31.0`'s manifest requires `org.eclipse.equinox.common;bundle-version="[3.18.0,4.0.0)"`; `equinox.bidi 1.3.0` is unchanged (satisfies `[0.10.0,2.0.0)`).

Changes:
- `pom.xml` (+4/-3): `jface.version` 3.22.0->3.31.0, `core.commands.version` 3.9.800->3.12.100, `equinox.common.version` 3.14.0->3.18.0, `equinox.bidi.version` 1.3.0 (unchanged)
- New test `editor/src/test/java/org/pentaho/pms/security/JFaceCveRegressionTest.java`

### Dependency tree (before -> after), `editor` module
Before: `org.eclipse.jface:3.22.0`, `core.commands:3.9.800`, `equinox.common:3.14.0`
After (BUILD SUCCESS, no 3.22.0 in the reactor): `org.eclipse.jface:3.31.0`, `core.commands:3.12.100`, `equinox.common:3.18.0`, `equinox.bidi:1.3.0`

### Tests
- The `editor` module (~40 jface UI classes) compiles clean against 3.31.0.
- Added a **RED-first regression guard** (`JFaceCveRegressionTest`) asserting the resolved `org.eclipse.jface` bundle is at/above the CVE-2023-4218 fixed line (3.29.0). Verified locally: **fails on 3.22.0** ("Vulnerable org.eclipse.jface 3.22.0... below the CVE-2023-4218 fixed line"), **passes on 3.31.0**.

### Review
Fixed and reviewed locally via codemedic-local-remediator before push.
